### PR TITLE
Fix docker-compose argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See `/_example/` for usage.
 
 ### Run
 
-`docker-compose up -f _example/docker-compose.yaml --scale autocache=5`
+`docker-compose -f _example/docker-compose.yaml up --scale autocache=5`
 
 ### Client
 


### PR DESCRIPTION
The docker-compose command line has the arguments in the wrong order. `-f $filename` should be before the subcommand.